### PR TITLE
Implement data integration and price model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ pip install -r requirements.txt
 python -m src.main ingest --input examples/sample_players.csv
 python -m src.main build-features
 python -m src.main price --method baseline
+python -m src.main train-prices --method linear
 python -m src.main rank --by value --role ALL --top 20 --budget 500
 ```
 
@@ -28,3 +29,15 @@ python -m src.main rank --by value --role ALL --top 20 --budget 500
 ## Output
 
 I risultati sono salvati in `data/` e `data/outputs/`.
+
+Il comando `train-prices` genera prezzi stimati dei giocatori
+utilizzando le statistiche storiche pesate e le quotazioni ufficiali.
+I risultati vengono salvati in `data/processed/derived_prices.csv` e
+un riepilogo del modello è disponibile in
+`data/outputs/price_model_summary.txt`.
+
+File di input richiesti per il training:
+
+- `quotes_2025_26_FVM_budget500.csv`
+- `stats_master_with_weights.csv`
+- `goalkeepers_grid_matrix_square.csv`

--- a/src/dataio.py
+++ b/src/dataio.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict
+import re
 
+import numpy as np
 import pandas as pd
 
 
@@ -39,3 +41,45 @@ def save_parquet(df: pd.DataFrame, path: Path) -> None:
 
 def load_parquet(path: Path) -> pd.DataFrame:
     return pd.read_parquet(path)
+
+
+def load_quotes(path: str) -> pd.DataFrame:
+    """Load processed quotes CSV and set default price column."""
+    df = pd.read_csv(path)
+    match = re.search(r"budget(\d+)", Path(path).stem)
+    budget = int(match.group(1)) if match else None
+    price_col = "price_from_fvm_500" if budget == 500 and "price_from_fvm_500" in df.columns else "fvm"
+    df["price"] = pd.to_numeric(df[price_col], errors="coerce")
+    return df
+
+
+def load_stats(path: str) -> pd.DataFrame:
+    """Load processed stats CSV ensuring numeric columns are floats."""
+    df = pd.read_csv(path)
+    numeric_cols = [
+        "season",
+        "season_weight",
+        "apps",
+        "avg",
+        "fanta_avg",
+        "goals",
+        "assists",
+        "yc",
+        "rc",
+        "pens_scored",
+        "pens_missed",
+        "own_goals",
+        "goals_conceded",
+    ]
+    for col in numeric_cols:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype(float)
+    return df
+
+
+def load_goalkeeper_grid(path: str) -> pd.DataFrame:
+    """Load goalkeeper grid as square matrix with NaN diagonal."""
+    df = pd.read_csv(path, index_col=0)
+    df = df.apply(pd.to_numeric, errors="coerce")
+    np.fill_diagonal(df.values, np.nan)
+    return df

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,9 @@ def parse_args() -> argparse.Namespace:
     p_price = sub.add_parser("price", help="Estimate prices")
     p_price.add_argument("--method", choices=["baseline", "heuristic"], default="baseline")
 
+    p_train = sub.add_parser("train-prices", help="Train price model")
+    p_train.add_argument("--method", choices=["linear", "tree"], default="linear")
+
     p_rank = sub.add_parser("rank", help="Rank players")
     p_rank.add_argument("--by", default="value")
     p_rank.add_argument("--role", default="ALL")
@@ -60,6 +63,17 @@ def main() -> None:
         out_path = utils.resolve_path(config, "processed") / "prices.parquet"
         dataio.save_parquet(priced, out_path)
         logger.info("Saved prices to %s", out_path)
+    elif args.command == "train-prices":
+        processed = utils.resolve_path(config, "processed")
+        stats_path = processed / "stats_master_with_weights.csv"
+        quotes_path = processed / "quotes_2025_26_FVM_budget500.csv"
+        stats = dataio.load_stats(stats_path)
+        quotes = dataio.load_quotes(quotes_path)
+        derived = pricing.train_price_model(stats, quotes, args.method)
+        out_path = processed / "derived_prices.csv"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        derived.to_csv(out_path, index=False)
+        logger.info("Saved derived prices to %s", out_path)
     elif args.command == "rank":
         in_path = utils.resolve_path(config, "processed") / "prices.parquet"
         df = dataio.load_parquet(in_path)

--- a/src/pricing.py
+++ b/src/pricing.py
@@ -1,11 +1,13 @@
 """Player pricing models."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict
 
 import numpy as np
 import pandas as pd
-from sklearn.linear_model import Ridge
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import Ridge, RidgeCV
 
 
 FEATURE_COLS = ["goals_per90", "assists_per90", "availability"]
@@ -40,3 +42,57 @@ def heuristic_price(df: pd.DataFrame, weights: Dict[str, float], budget: float) 
     )
     ev = score.to_numpy()
     return _normalize_budget(df, ev, budget)
+
+
+def train_price_model(
+    stats: pd.DataFrame, quotes: pd.DataFrame, method: str = "linear"
+) -> pd.DataFrame:
+    """Train model to estimate fair prices from stats and quotes."""
+    numeric_cols = [
+        c
+        for c in stats.select_dtypes(include="number").columns
+        if c not in {"season", "season_weight"}
+    ]
+    weighted = stats.copy()
+    weighted[numeric_cols] = weighted[numeric_cols].multiply(
+        weighted["season_weight"], axis=0
+    )
+    agg = (
+        weighted.groupby(["id", "name", "team", "role"])[numeric_cols]
+        .sum()
+        .reset_index()
+    )
+    df = agg.merge(quotes, on=["id", "name", "team", "role"], how="inner")
+    X = df[numeric_cols]
+    y = df["fvm"]
+
+    if method == "linear":
+        model = RidgeCV(alphas=np.logspace(-3, 3, 7))
+        model.fit(X, y)
+        summary = {col: coef for col, coef in zip(numeric_cols, model.coef_)}
+    else:
+        model = RandomForestRegressor(max_depth=5, n_estimators=100, random_state=0)
+        model.fit(X, y)
+        summary = {
+            col: imp for col, imp in zip(numeric_cols, model.feature_importances_)
+        }
+
+    df["estimated_price"] = model.predict(X)
+
+    out_path = Path("data/outputs/price_model_summary.txt")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as fh:
+        for col, val in summary.items():
+            fh.write(f"{col}: {val}\n")
+
+    return df[
+        [
+            "id",
+            "name",
+            "team",
+            "role",
+            "fvm",
+            "price_from_fvm_500",
+            "estimated_price",
+        ]
+    ]


### PR DESCRIPTION
## Summary
- add loaders for quotes, stats, and goalkeeper grid CSVs
- train pricing model via linear or tree methods and output summary
- expose `train-prices` CLI command and document derived price workflow

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae2a3d204832baaf1ce4ed124ae27