### PR TITLE
Add roster optimizer with dual price strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,32 @@ File di input richiesti per il training:
 - `quotes_2025_26_FVM_budget500.csv`
 - `stats_master_with_weights.csv`
 - `goalkeepers_grid_matrix_square.csv`
+
+## UI
+
+L'app Streamlit offre:
+
+- barra di ricerca con dettagli del giocatore e raccomandazione BUY/AVOID;
+- gestione del log d'asta con aggiornamento di budget e roster;
+- ottimizzatore del roster completo.
+
+### Strategie di prezzo
+
+Le strategie disponibili sono:
+
+- `estimated`: usa `estimated_price` se disponibile, altrimenti `price_500`;
+- `fvm500`: usa sempre `price_500`;
+- `blend`: combina i due prezzi con peso \(\alpha\).
+
+Il punteggio di valore è `expected_points / effective_price`.
+
+### Roster Optimizer
+
+L'ottimizzatore seleziona 25 giocatori (3P/8D/8C/6A) rispettando il budget
+di 500 crediti e il vincolo di massimo 3 giocatori per squadra.
+Il roster consigliato è salvato in `data/outputs/recommended_roster.csv`.
+
+### Esportazioni
+
+Il pannello "Il mio roster" mostra i giocatori acquistati e permette di
+esportare il roster in `data/outputs/my_roster.csv`.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,0 +1,125 @@
+"""Streamlit UI for roster optimisation."""
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from src import dataio, services
+
+
+DATA_PROCESSED = "data/processed"
+OUTPUT_DIR = "data/outputs"
+AUCTION_LOG = f"{OUTPUT_DIR}/auction_log.csv"
+
+
+@st.cache_data
+def load_players() -> pd.DataFrame:
+    quotes = f"{DATA_PROCESSED}/quotes_2025_26_FVM_budget500.csv"
+    derived = f"{DATA_PROCESSED}/derived_prices.csv"
+    players = dataio.load_quotes(quotes, derived)
+    # expected_points may come from separate processing; default 0
+    if "expected_points" not in players.columns:
+        players["expected_points"] = 0.0
+    return players
+
+
+def read_log() -> pd.DataFrame:
+    try:
+        return pd.read_csv(AUCTION_LOG)
+    except FileNotFoundError:
+        return pd.DataFrame(columns=["id", "name", "team", "role", "price_paid", "acquired"])
+
+
+def append_log(entry: dict) -> None:
+    log = read_log()
+    log = pd.concat([log, pd.DataFrame([entry])], ignore_index=True)
+    log.to_csv(AUCTION_LOG, index=False)
+
+
+players = load_players()
+st.title("Fantacalcio Roster Optimizer")
+
+# price strategy controls
+strategy = st.selectbox("Price strategy", ["estimated", "fvm500", "blend"], index=0)
+alpha = st.slider("Blend alpha", 0.0, 1.0, 0.6)
+players["effective_price"] = services.choose_price(players, strategy, alpha)
+players["value_score"] = players["expected_points"] / players["effective_price"]
+
+# search bar
+name = st.selectbox("Search player", players["name"].sort_values())
+sel = players[players["name"] == name].iloc[0]
+
+st.subheader("Player details")
+st.write(
+    {
+        "fvm": sel.get("fvm"),
+        "price_500": sel.get("price_500"),
+        "estimated_price": sel.get("estimated_price"),
+        "expected_points": sel.get("expected_points"),
+        "value_score": sel.get("value_score"),
+    }
+)
+
+# recommendation badge
+log = read_log()
+state = services.RosterState(
+    budget_residual=500 - pd.to_numeric(log.get("price_paid", 0)).sum(),
+    team_cap=3,
+    team_counts=log[log.get("acquired", 0) == 1]["team"].value_counts().to_dict(),
+    slots_needed={r: services.QUOTAS[r] - log[log.get("acquired", 0) == 1]["role"].value_counts().to_dict().get(r, 0) for r in services.QUOTAS},
+    value_threshold=players["value_score"].quantile(0.6),
+)
+rec = services.recommend_player(sel, state)
+st.markdown(f"**Recommendation:** {rec['label']} - {rec['reason']}")
+
+# auction log form
+st.subheader("Auction log")
+with st.form("auction_form"):
+    price_paid = st.number_input("Price paid", min_value=0, step=1)
+    acquired = st.checkbox("Acquired", value=True)
+    submitted = st.form_submit_button("Log")
+    if submitted:
+        append_log(
+            {
+                "id": sel["id"],
+                "name": sel["name"],
+                "team": sel["team"],
+                "role": sel["role"],
+                "price_paid": int(price_paid),
+                "acquired": int(acquired),
+            }
+        )
+        st.success("Entry added to log")
+
+
+st.subheader("Roster Optimizer")
+budget_total = st.number_input("Total budget", value=500)
+team_cap = st.number_input("Team cap", value=3)
+if st.button("Optimize"):
+    roster = services.optimize_roster(
+        players, log, budget_total, team_cap, strategy, alpha
+    )
+    roster.to_csv(f"{OUTPUT_DIR}/recommended_roster.csv", index=False)
+    st.dataframe(
+        roster[
+            [
+                "role",
+                "name",
+                "team",
+                "expected_points",
+                "effective_price",
+                "value_score",
+                "cum_budget",
+            ]
+        ]
+    )
+
+st.sidebar.subheader("Il mio roster")
+acquired = log[log.get("acquired", 0) == 1]
+spent = pd.to_numeric(acquired.get("price_paid", 0), errors="coerce").sum()
+counts = acquired["role"].value_counts().to_dict()
+st.sidebar.write({"spent": spent, "budget_residual": 500 - spent, "counts": counts})
+if st.sidebar.button("Esporta il mio roster"):
+    acquired.to_csv(f"{OUTPUT_DIR}/my_roster.csv", index=False)
+    st.sidebar.success("Roster esportato")
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Ensure project root is on sys.path for tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib==3.9.0
 pyyaml==6.0.2
 pytest==8.2.0
 pyarrow>=15.0.0     # required by pandas.to_parquet
+streamlit==1.38.0

--- a/src/dataio.py
+++ b/src/dataio.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict
-import re
 
 import numpy as np
 import pandas as pd
@@ -43,13 +42,41 @@ def load_parquet(path: Path) -> pd.DataFrame:
     return pd.read_parquet(path)
 
 
-def load_quotes(path: str) -> pd.DataFrame:
-    """Load processed quotes CSV and set default price column."""
-    df = pd.read_csv(path)
-    match = re.search(r"budget(\d+)", Path(path).stem)
-    budget = int(match.group(1)) if match else None
-    price_col = "price_from_fvm_500" if budget == 500 and "price_from_fvm_500" in df.columns else "fvm"
-    df["price"] = pd.to_numeric(df[price_col], errors="coerce")
+def load_quotes(quotes_path: str, derived_path: str | None = None) -> pd.DataFrame:
+    """Load quotes and optional derived prices.
+
+    Parameters
+    ----------
+    quotes_path:
+        Path to ``quotes_2025_26_FVM_budget500.csv``.
+    derived_path:
+        Optional path to ``derived_prices.csv`` containing ``estimated_price``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``fvm``, ``price_500`` and ``estimated_price``.
+    """
+
+    quotes = pd.read_csv(quotes_path)
+    cols = [c for c in ["id", "name", "team", "role", "fvm", "price_from_fvm_500"] if c in quotes.columns]
+    df = quotes[cols].rename(columns={"price_from_fvm_500": "price_500"})
+
+    df["fvm"] = pd.to_numeric(df["fvm"], errors="coerce").fillna(0)
+    df["price_500"] = pd.to_numeric(df["price_500"], errors="coerce").fillna(0)
+
+    if derived_path and Path(derived_path).exists():
+        derived = pd.read_csv(derived_path)
+        if "estimated_price" in derived.columns:
+            derived["estimated_price"] = pd.to_numeric(
+                derived["estimated_price"], errors="coerce"
+            )
+            df = df.merge(derived[["id", "estimated_price"]], on="id", how="left")
+        else:
+            df["estimated_price"] = np.nan
+    else:
+        df["estimated_price"] = np.nan
+
     return df
 
 

--- a/src/services.py
+++ b/src/services.py
@@ -1,0 +1,184 @@
+"""Service layer helpers for pricing and roster optimisation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Literal
+
+import numpy as np
+import pandas as pd
+
+
+PRICE_STRATEGY = Literal["estimated", "fvm500", "blend"]
+
+
+def choose_price(
+    players: pd.DataFrame,
+    strategy: PRICE_STRATEGY,
+    alpha: float = 0.6,
+) -> pd.Series:
+    """Select an effective price for each player.
+
+    Parameters
+    ----------
+    players:
+        DataFrame with ``price_500`` and ``estimated_price`` columns.
+    strategy:
+        ``"estimated"``, ``"fvm500"`` or ``"blend"``.
+    alpha:
+        Weight for ``estimated_price`` when ``strategy='blend'``.
+    """
+
+    price_500 = pd.to_numeric(players["price_500"], errors="coerce").fillna(0)
+    est = pd.to_numeric(players.get("estimated_price"), errors="coerce")
+
+    if strategy == "estimated":
+        effective = est.fillna(price_500)
+    elif strategy == "fvm500":
+        effective = price_500
+    elif strategy == "blend":
+        blended = est.fillna(price_500)
+        effective = alpha * blended + (1 - alpha) * price_500
+    else:
+        raise ValueError(f"Unknown strategy: {strategy}")
+
+    return effective.clip(lower=1)
+
+
+# ---------------------------------------------------------------------------
+# Roster optimiser
+
+QUOTAS: Dict[str, int] = {"P": 3, "D": 8, "C": 8, "A": 6}
+
+
+def _initial_state(auction_log: pd.DataFrame | None) -> Dict[str, Dict[str, int]]:
+    roles = {r: 0 for r in QUOTAS}
+    teams: Dict[str, int] = {}
+    spent = 0.0
+    if auction_log is not None and not auction_log.empty:
+        acquired = auction_log[auction_log.get("acquired", 0) == 1]
+        roles.update(acquired["role"].value_counts().to_dict())
+        teams = acquired["team"].value_counts().to_dict()
+        spent = pd.to_numeric(acquired.get("price_paid", 0), errors="coerce").sum()
+    return {"roles": roles, "teams": teams, "spent": spent}
+
+
+def optimize_roster(
+    players: pd.DataFrame,
+    auction_log: pd.DataFrame | None = None,
+    budget_total: float = 500,
+    team_cap: int = 3,
+    price_strategy: PRICE_STRATEGY = "estimated",
+    alpha: float = 0.6,
+    allow_low_mins: bool = False,
+    grid_matrix: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Greedy roster optimisation.
+
+    Returns a DataFrame with selected players and cumulative budget used.
+    """
+
+    state = _initial_state(auction_log)
+    budget_residual = budget_total - state["spent"]
+
+    pool = players.copy()
+    if not allow_low_mins and "apps" in pool.columns:
+        pool = pool[pool["apps"] >= 8]
+
+    # exclude already acquired players
+    if auction_log is not None and not auction_log.empty:
+        acquired_ids = auction_log[auction_log.get("acquired", 0) == 1]["id"].tolist()
+        pool = pool[~pool["id"].isin(acquired_ids)]
+
+    pool["effective_price"] = choose_price(pool, price_strategy, alpha)
+    pool["value_score"] = pool["expected_points"] / pool["effective_price"].clip(lower=1)
+
+    selected = []
+    spent = 0.0
+
+    for role, quota in QUOTAS.items():
+        current = state["roles"].get(role, 0)
+        needed = quota - current
+        if needed <= 0:
+            continue
+
+        candidates = pool[pool["role"] == role].copy()
+        candidates = candidates.sort_values(
+            ["value_score", "expected_points", "effective_price"],
+            ascending=[False, False, True],
+        )
+
+        for _, row in candidates.iterrows():
+            if needed <= 0:
+                break
+            if spent + row["effective_price"] > budget_residual:
+                continue
+            if state["teams"].get(row["team"], 0) >= team_cap:
+                continue
+
+            selected.append(row)
+            spent += row["effective_price"]
+            state["teams"][row["team"]] = state["teams"].get(row["team"], 0) + 1
+            needed -= 1
+
+        if needed > 0:
+            raise RuntimeError(f"Insufficient data or budget for role {role}")
+
+    roster = pd.DataFrame(selected)
+    if roster.empty:
+        return roster
+
+    roster["cum_budget"] = roster["effective_price"].cumsum()
+
+    if grid_matrix is not None:
+        gks = roster[roster["role"] == "P"]
+        if len(gks) == 3:
+            teams = gks["team"].tolist()
+            vals = []
+            for i in range(3):
+                for j in range(i + 1, 3):
+                    vals.append(grid_matrix.loc[teams[i], teams[j]])
+            avg = np.nanmean(vals)
+            roster.attrs["goalkeeper_grid_avg"] = avg
+            if avg < 8:
+                roster.attrs["goalkeeper_penalty"] = 0.5
+            else:
+                roster.attrs["goalkeeper_penalty"] = 0.0
+
+    return roster
+
+
+# ---------------------------------------------------------------------------
+# Player recommendation
+
+
+@dataclass
+class RosterState:
+    """Minimal representation of current roster status."""
+
+    budget_residual: float
+    team_cap: int
+    team_counts: Dict[str, int]
+    slots_needed: Dict[str, int]
+    value_threshold: float
+
+
+def recommend_player(row: pd.Series, roster_state: RosterState) -> Dict[str, str]:
+    """Return BUY/AVOID recommendation for a player."""
+
+    team_count = roster_state.team_counts.get(row["team"], 0)
+    if team_count >= roster_state.team_cap:
+        return {"label": "AVOID", "reason": "team cap reached"}
+
+    slots_left = sum(roster_state.slots_needed.values()) or 1
+    budget_per_slot = roster_state.budget_residual / slots_left
+    if row["effective_price"] > budget_per_slot:
+        return {"label": "AVOID", "reason": "price too high"}
+
+    threshold = roster_state.value_threshold
+    if roster_state.slots_needed.get(row["role"], 0) > 0:
+        threshold *= 0.9  # slightly easier if role is needed
+
+    if row["value_score"] >= threshold:
+        return {"label": "BUY", "reason": "value above threshold"}
+    return {"label": "AVOID", "reason": "low value"}
+

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pandas as pd
+
+from src import services
+
+
+def _sample_players() -> pd.DataFrame:
+    rows = []
+    for role, quota in services.QUOTAS.items():
+        for i in range(quota + 2):  # extra candidates
+            rows.append(
+                {
+                    "id": f"{role}{i}",
+                    "name": f"{role}{i}",
+                    "team": f"T{i%5}",
+                    "role": role,
+                    "expected_points": 10 + i,
+                    "price_500": 10,
+                    "estimated_price": 12,
+                    "apps": 10,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_choose_price_blend_and_fallback():
+    df = pd.DataFrame(
+        {
+            "price_500": [10, 20],
+            "estimated_price": [15, np.nan],
+        }
+    )
+    blended = services.choose_price(df, "blend", alpha=0.5)
+    assert blended.iloc[0] == 12.5
+    assert blended.iloc[1] == 20
+
+    est = services.choose_price(df, "estimated")
+    assert est.iloc[1] == 20
+
+
+def test_optimizer_respects_quotas_and_budget():
+    players = _sample_players()
+    roster = services.optimize_roster(players, budget_total=500, team_cap=10, price_strategy="fvm500")
+    assert len(roster) == sum(services.QUOTAS.values())
+    counts = roster["role"].value_counts().to_dict()
+    for role, qty in services.QUOTAS.items():
+        assert counts.get(role, 0) == qty
+    assert roster["effective_price"].sum() <= 500
+


### PR DESCRIPTION
## Summary
- Load official and derived prices and keep fvm, price_500, and estimated_price
- Implement price selection, greedy roster optimizer and player recommendation services
- Add Streamlit UI with search, auction logging, and roster optimization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae8d2ec1c832bbcf8511712db675f