### PR TITLE
fix(streamlit): ensure src is importable when running from app/

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,6 +1,11 @@
 """Streamlit UI for roster optimisation."""
 from __future__ import annotations
 
+import sys, os
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
 import pandas as pd
 import streamlit as st
 
@@ -10,6 +15,23 @@ from src import dataio, services
 DATA_PROCESSED = "data/processed"
 OUTPUT_DIR = "data/outputs"
 AUCTION_LOG = f"{OUTPUT_DIR}/auction_log.csv"
+
+REQUIRED_FILES = [
+    f"{DATA_PROCESSED}/quotes_2025_26_FVM_budget500.csv",
+    f"{DATA_PROCESSED}/stats_master_with_weights.csv",
+    f"{DATA_PROCESSED}/derived_prices.csv",
+]
+missing_files = [f for f in REQUIRED_FILES if not os.path.exists(f)]
+DISABLED = bool(missing_files)
+if DISABLED:
+    message = "Missing required data files:\n" + "\n".join(
+        f"- {f}" for f in missing_files
+    )
+    if f"{DATA_PROCESSED}/derived_prices.csv" in missing_files:
+        message += (
+            "\nTo generate derived prices run: `python -m src.main train-prices --method linear`"
+        )
+    st.error(message)
 
 
 @st.cache_data
@@ -36,12 +58,31 @@ def append_log(entry: dict) -> None:
     log.to_csv(AUCTION_LOG, index=False)
 
 
-players = load_players()
+players = load_players() if not DISABLED else pd.DataFrame()
 st.title("Fantacalcio Roster Optimizer")
 
 # price strategy controls
-strategy = st.selectbox("Price strategy", ["estimated", "fvm500", "blend"], index=0)
-alpha = st.slider("Blend alpha", 0.0, 1.0, 0.6)
+strategy = st.selectbox(
+    "Price strategy", ["estimated", "fvm500", "blend"], index=0, disabled=DISABLED
+)
+alpha = st.slider("Blend alpha", 0.0, 1.0, 0.6, disabled=DISABLED)
+
+if DISABLED:
+    st.selectbox("Search player", [], disabled=True)
+    st.subheader("Auction log")
+    with st.form("auction_form"):
+        st.number_input("Price paid", min_value=0, step=1, disabled=True)
+        st.checkbox("Acquired", value=True, disabled=True)
+        st.form_submit_button("Log", disabled=True)
+    st.subheader("Roster Optimizer")
+    st.number_input("Total budget", value=500, disabled=True)
+    st.number_input("Team cap", value=3, disabled=True)
+    st.button("Optimize", disabled=True)
+    st.sidebar.subheader("Il mio roster")
+    st.sidebar.write({})
+    st.sidebar.button("Esporta il mio roster", disabled=True)
+    st.stop()
+
 players["effective_price"] = services.choose_price(players, strategy, alpha)
 players["value_score"] = players["expected_points"] / players["effective_price"]
 


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` so `src` imports succeed when launching from `app/`
- show helpful error when required data files are missing and disable the UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baf736495c832bb15044353de31358