### PR TITLE
fix: idempotent training (CSV first, DB replace/upsert) + optional reset DB

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -6,9 +6,32 @@ from typing import Dict, Literal
 
 import numpy as np
 import pandas as pd
+from sqlalchemy import Engine, text
 
 
 PRICE_STRATEGY = Literal["estimated", "fvm500", "blend"]
+
+
+def upsert_players(engine: Engine, df: pd.DataFrame) -> None:
+    """Upsert player records into SQLite ``players`` table.
+
+    Uses ``ON CONFLICT(id) DO UPDATE`` so rerunning imports does not
+    raise duplicate key errors.
+    """
+
+    if df.empty:
+        return
+
+    cols = list(df.columns)
+    placeholders = ", ".join(f":{c}" for c in cols)
+    updates = ", ".join(f"{c}=excluded.{c}" for c in cols if c != "id")
+    stmt = text(
+        f"INSERT INTO players ({', '.join(cols)}) VALUES ({placeholders}) "
+        f"ON CONFLICT(id) DO UPDATE SET {updates}"
+    )
+    records = df.to_dict(orient="records")
+    with engine.begin() as conn:
+        conn.execute(stmt, records)
 
 
 def choose_price(


### PR DESCRIPTION
## Summary
- return the derived price DataFrame and persist it to SQLite using REPLACE after writing CSV
- add `upsert_players` helper to perform SQLite UPSERTs on the players table
- support resetting the database from the sidebar and upsert players on load

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bafd3c2ddc832ba9e63169613e5523