### PR TITLE
feat: track sold players

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,5 +1,6 @@
 import os
-from sqlalchemy import create_engine, String, Integer, Float
+from datetime import datetime
+from sqlalchemy import create_engine, String, Integer, Float, select
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session
 from src.core.paths import db_uri
 
@@ -17,6 +18,9 @@ class Player(Base):
     fvm: Mapped[int] = mapped_column(Integer, nullable=True)
     price_500: Mapped[int] = mapped_column(Integer, nullable=False)
     expected_points: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    is_sold: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    sold_price: Mapped[int] = mapped_column(Integer, nullable=True)
+    sold_at: Mapped[str] = mapped_column(String, nullable=True)
 
 
 _engine = create_engine(os.environ.get("FANTA_DB_URL", db_uri()), future=True)
@@ -40,3 +44,55 @@ def upsert_players(rows: list[dict]):
         for r in rows:
             s.merge(Player(**r))
         s.commit()
+
+
+def get_player(player_id: int) -> Player | None:
+    with Session(_engine) as s:
+        return s.get(Player, player_id)
+
+
+def mark_player_sold(player_id: int, price: int | None) -> tuple[bool, str | None]:
+    with Session(_engine) as s:
+        p = s.get(Player, player_id)
+        if p is None:
+            return False, "Player not found"
+        if p.is_sold:
+            return False, "Player already sold"
+        p.is_sold = 1
+        p.sold_price = price
+        p.sold_at = datetime.utcnow().isoformat()
+        s.commit()
+        return True, None
+
+
+def mark_player_unsold(player_id: int) -> tuple[bool, str | None]:
+    with Session(_engine) as s:
+        p = s.get(Player, player_id)
+        if p is None:
+            return False, "Player not found"
+        if not p.is_sold:
+            return False, "Player not sold"
+        p.is_sold = 0
+        p.sold_price = None
+        p.sold_at = None
+        s.commit()
+        return True, None
+
+
+def list_searchable_players(
+    q: str | None = None,
+    role: str | None = None,
+    team: str | None = None,
+    include_sold: bool = False,
+) -> list[Player]:
+    with Session(_engine) as s:
+        stmt = select(Player)
+        if q:
+            stmt = stmt.where(Player.name.ilike(f"%{q}%"))
+        if role:
+            stmt = stmt.where(Player.role == role)
+        if team:
+            stmt = stmt.where(Player.team == team)
+        if not include_sold:
+            stmt = stmt.where(Player.is_sold == 0)
+        return list(s.scalars(stmt))


### PR DESCRIPTION
## Summary
- add sold tracking fields and helper functions to Player DB model
- update Streamlit UI to hide sold players, log sales, and allow undo

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc1dcfdf40832b84e614426be6fbe3