### PR TITLE
Gestione separata del mio roster con rimozione e budget

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -24,6 +24,10 @@ class Player(Base):
     is_sold: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     sold_price: Mapped[int | None] = mapped_column(Integer, nullable=True)
     sold_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Tracking acquisti personali
+    my_acquired: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    my_price: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    my_acquired_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
 DB_URL = os.environ.get("FANTA_DB_URL", "sqlite:///data/fanta.db")
 _engine = create_engine(DB_URL, future=True)
@@ -46,6 +50,12 @@ def init_db(drop: bool = False):
             conn.exec_driver_sql("ALTER TABLE players ADD COLUMN sold_price INTEGER")
         if "sold_at" not in cols:
             conn.exec_driver_sql("ALTER TABLE players ADD COLUMN sold_at TEXT")
+        if "my_acquired" not in cols:
+            conn.exec_driver_sql("ALTER TABLE players ADD COLUMN my_acquired INTEGER NOT NULL DEFAULT 0")
+        if "my_price" not in cols:
+            conn.exec_driver_sql("ALTER TABLE players ADD COLUMN my_price INTEGER")
+        if "my_acquired_at" not in cols:
+            conn.exec_driver_sql("ALTER TABLE players ADD COLUMN my_acquired_at TEXT")
 
 
 def upsert_players(rows: list[dict]):


### PR DESCRIPTION
## Summary
- Track personal acquisitions with new DB fields `my_acquired`, `my_price` e `my_acquired_at`
- Aggiunto blocco "Il mio roster" in UI con ordinamento P→D→C→A, visualizzazione prezzi e rimozione multipla
- Logging asta integra i miei acquisti aggiornando il roster personale

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc293ccf5c832b9b455ca0c40f4f2d