### PR TITLE
Handle absent roster tracking fields

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -59,6 +59,8 @@ ROLE_ORDER = {"P": 1, "D": 2, "C": 3, "A": 4}
 
 
 def _add_to_my_roster(player_id: int, price: int | None = None):
+    if not hasattr(Player, "my_acquired"):
+        return False, "Roster tracking not supported"
     with Session(engine()) as s:
         p = s.get(Player, int(player_id))
         if not p:
@@ -73,6 +75,8 @@ def _add_to_my_roster(player_id: int, price: int | None = None):
 
 
 def _remove_from_my_roster(player_id: int):
+    if not hasattr(Player, "my_acquired"):
+        return False, "Roster tracking not supported"
     with Session(engine()) as s:
         p = s.get(Player, int(player_id))
         if not p:
@@ -85,6 +89,8 @@ def _remove_from_my_roster(player_id: int):
 
 
 def _list_my_roster():
+    if not hasattr(Player, "my_acquired"):
+        return []
     with Session(engine()) as s:
         q = s.query(Player).filter(Player.my_acquired == 1)
         items = q.all()
@@ -93,6 +99,8 @@ def _list_my_roster():
 
 
 def _budget_stats(budget_total: int):
+    if not hasattr(Player, "my_acquired"):
+        return 0, int(budget_total)
     with Session(engine()) as s:
         total = (
             s.query(Player)


### PR DESCRIPTION
## Summary
- Avoid AttributeError when Player.my_acquired column is missing by checking field availability in roster helpers
- Skip roster tracking logic if column not present, returning empty roster and default budget stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ba9ed24832ba10a42c6bd40d52d