### PR TITLE
Fix roster caching and DB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ Il roster consigliato è salvato in `data/outputs/recommended_roster.csv`.
 
 Il pannello "Il mio roster" mostra i giocatori acquistati e permette di
 esportare il roster in `data/outputs/my_roster.csv`.
+
+### Il mio roster
+
+Dal pannello "Log d'asta" è possibile spuntare **Acquired** per segnare
+un giocatore come acquistato; il giocatore viene salvato nel database
+`data/fanta.db` e appare immediatamente nella sezione "Il mio roster"
+senza bisogno di ricaricare manualmente la pagina.

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,41 @@
+import os
+from datetime import datetime
+
+os.environ["FANTA_DB_URL"] = "sqlite:///:memory:"
+
+from src.db import (
+    init_db,
+    upsert_players,
+    mark_player_acquired,
+    get_my_roster,
+    Player,
+    get_session,
+)
+
+
+def test_mark_player_acquired_and_roster_fetch():
+    init_db()
+    upsert_players(
+        [
+            {
+                "id": 1,
+                "name": "Foo",
+                "team": "AAA",
+                "role": "P",
+                "fvm": 1,
+                "price_500": 10,
+                "expected_points": 5.0,
+            }
+        ]
+    )
+    mark_player_acquired(1, 7, when="2024-01-01T00:00:00")
+    roster = get_my_roster()
+    assert len(roster) == 1
+    p = roster[0]
+    assert p.my_acquired == 1
+    assert p.my_price == 7
+    assert isinstance(p.my_acquired_at, datetime)
+    with get_session() as s:
+        db_p = s.get(Player, 1)
+        assert db_p.my_acquired == 1
+        assert db_p.my_price == 7


### PR DESCRIPTION
## Summary
- centralize SQLite path and engine setup with foreign keys and WAL
- add helper to mark players as acquired and fetch roster
- refresh Streamlit roster view after auction log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2f552a70832b977c30b92a4887e2