### PR TITLE
feat: load GK grid from raw data with fallbacks

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -307,7 +307,11 @@ if p is not None:
     gk_signal = None
     owned_gk_team = None
     if role == "P":
-        grid = GKGrid()
+        grid = GKGrid()  # usa il percorso preferito data/raw/...
+        if not grid.available:
+            st.info(
+                "⚠️ GK grid non trovato in data/raw: raccomandazione portieri calcolata solo su price/fair."
+            )
         roster = get_my_roster()
         owned_gk = next((pl for pl in roster if pl.role == "P"), None)
         if owned_gk:

--- a/src/gk_grid.py
+++ b/src/gk_grid.py
@@ -1,10 +1,17 @@
+"""Goalkeeper grid handling with flexible file resolution."""
+
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 
-GRID_PATH = Path("data/goalkeepers_grid_matrix_square.csv")
+
+# nome file atteso
+GRID_FILENAME = "goalkeepers_grid_matrix_square.csv"
+
 
 TEAM_ALIAS = {
     "ATALANTA": "ATA",
@@ -30,17 +37,74 @@ TEAM_ALIAS = {
 }
 
 
+def _candidate_paths() -> list[Path]:
+    """Possibili posizioni per il CSV (più robuste)."""
+
+    here = Path(__file__).resolve()
+    src_root = here.parent  # .../src
+    repo_root = src_root.parent  # repo root
+    cwd = Path.cwd()
+    env = os.getenv("GK_GRID_PATH", "")
+
+    cands: list[Path] = []
+    if env:
+        p = Path(env)
+        cands.append(p if p.name.endswith(".csv") else p / GRID_FILENAME)
+
+    # Ordine: preferito = data/raw/, poi fallback legacy
+    cands += [
+        # percorso corretto richiesto
+        repo_root / "data" / "raw" / GRID_FILENAME,
+        cwd / "data" / "raw" / GRID_FILENAME,
+        Path("data") / "raw" / GRID_FILENAME,
+        # fallback legacy/supporto
+        repo_root / "data" / GRID_FILENAME,
+        cwd / "data" / GRID_FILENAME,
+        Path("data") / GRID_FILENAME,
+        repo_root / "app" / "data" / GRID_FILENAME,
+    ]
+
+    # dedup preservando ordine
+    seen: set[str] = set()
+    uniq: list[Path] = []
+    for p in cands:
+        if p and str(p) not in seen:
+            uniq.append(p)
+            seen.add(str(p))
+    return uniq
+
+
 class GKGrid:
-    def __init__(self, path: str | Path = GRID_PATH):
-        self.df = pd.read_csv(path, index_col=0)
-        self.df.index = self.df.index.str.strip().str.upper()
-        self.df.columns = self.df.columns.str.strip().str.upper()
+    def __init__(self, path: Optional[str | Path] = None):
+        """Se il file non esiste: available=False, nessuna eccezione."""
+
+        self.available = False
+        self.df: Optional[pd.DataFrame] = None
+        self.resolved_path: Optional[Path] = None
+
+        if path:
+            p = Path(path)
+            paths = [p if p.name.endswith(".csv") else p / GRID_FILENAME]
+        else:
+            paths = _candidate_paths()
+
+        for candidate in paths:
+            if candidate.exists():
+                df = pd.read_csv(candidate, index_col=0)
+                df.index = df.index.str.strip().str.upper()
+                df.columns = df.columns.str.strip().str.upper()
+                self.df = df
+                self.available = True
+                self.resolved_path = candidate
+                break
 
     def _norm(self, team: str) -> str:
         t = team.strip().upper()
         return TEAM_ALIAS.get(t, t)
 
     def score_pair(self, team_a: str, team_b: str) -> float:
+        if not self.available or self.df is None:
+            return 0.0
         a = self._norm(team_a)
         b = self._norm(team_b)
         if a in self.df.index and b in self.df.columns:
@@ -48,6 +112,10 @@ class GKGrid:
         return 0.0
 
     def single_score(self, team: str) -> float:
+        """Valuta un team senza vincolo: media assoluta della riga (più bassa è meglio)."""
+
+        if not self.available or self.df is None:
+            return 0.0
         t = self._norm(team)
         if t in self.df.index:
             row = self.df.loc[t].astype(float).abs()
@@ -57,3 +125,4 @@ class GKGrid:
 
 def grid_signal_from_value(v: float) -> float:
     return -abs(v)
+

--- a/tests/test_gk_grid.py
+++ b/tests/test_gk_grid.py
@@ -1,0 +1,10 @@
+from src.gk_grid import GKGrid
+
+
+def test_missing_grid_file(tmp_path):
+    missing = tmp_path / "non_existing.csv"
+    grid = GKGrid(missing)
+    assert not grid.available
+    assert grid.single_score("A") == 0.0
+    assert grid.score_pair("A", "B") == 0.0
+


### PR DESCRIPTION
## Summary
- load GK grid from `data/raw/goalkeepers_grid_matrix_square.csv` by default with legacy fallbacks
- surface info message in UI when grid file is missing
- test grid behavior when the CSV is absent

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc3a17547c832ba568bd3499bc2de6