### PR TITLE
feat: enhance goalkeeper grid path and team normalization

### DIFF
--- a/tests/test_gk_grid.py
+++ b/tests/test_gk_grid.py
@@ -8,3 +8,16 @@ def test_missing_grid_file(tmp_path):
     assert grid.single_score("A") == 0.0
     assert grid.score_pair("A", "B") == 0.0
 
+
+def test_grid_default_and_aliases():
+    """Ensure the grid loads default path and normalizes team names."""
+
+    grid = GKGrid()  # use default file resolution
+    assert grid.available
+    # full names map to 3-letter codes
+    assert grid.score_pair("Atalanta", "Bologna") == 12.0
+    # alias handling (Internazionale -> INT)
+    assert grid.score_pair("Internazionale", "Juventus") == 12.0
+    # single score uses normalized headers
+    assert grid.single_score("Atalanta") == 9.0
+


### PR DESCRIPTION
## Summary
- add default grid path and expand team alias normalization
- improve candidate CSV search and team name matching
- ensure goalkeeper grid loads default file and resolves aliases through tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d1a16a4832b80f4568f516fc394