### PR TITLE
Use composite fanta_avg/price metric for recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 ```bash
 python -m src.main ingest --input examples/sample_players.csv
 python -m src.main build-features
-python -m src.main rank --by value_score --role ALL --top 20 --budget 500
+python -m src.main rank --by score_z_role --role ALL --top 20 --budget 500
 ```
 
 ## Esempio input
@@ -32,7 +32,16 @@ I risultati sono salvati in `data/` e `data/outputs/`.
 
 Il database SQLite `data/fanta.db` contiene la tabella `players` ed è creato automaticamente.
 
-Il punteggio di valore è `expected_points / price_500`.
+La metrica composita per le raccomandazioni è:
+
+```
+price_pct_role = rank_pct(price_500 | per ruolo, ascending=True)
+score_raw = 0.70 * fanta_avg + 0.30 * price_pct_role
+score_z_role = zscore(score_raw | per ruolo)
+```
+
+La label Recommendation usa le soglie configurabili `BUY alpha` e `HOLD alpha`
+sul relativo `score_z_role`.
 
 ## UI
 

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ def parse_args() -> argparse.Namespace:
     sub.add_parser("build-features", help="Generate features")
 
     p_rank = sub.add_parser("rank", help="Rank players")
-    p_rank.add_argument("--by", default="value_score")
+    p_rank.add_argument("--by", default="score_z_role")
     p_rank.add_argument("--role", default="ALL")
     p_rank.add_argument("--top", type=int, default=10)
     p_rank.add_argument("--budget", type=float, default=0)

--- a/src/reco.py
+++ b/src/reco.py
@@ -1,53 +1,109 @@
+"""Recommendation scoring based on fanta_avg and price percentiles."""
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from . import dataio
 
 
 @dataclass
 class RecConfig:
-    buy_alpha: float = 0.15
+    """Thresholds for classification on z-scores."""
+
+    buy_alpha: float = 1.0
     hold_alpha: float = -0.05
-    w_price: float = 0.5
-    w_grid: float = 0.5
 
 
-def value_alpha_from_fair(fair_value: Optional[float], price_500: Optional[float]) -> float:
-    if not fair_value or not price_500 or price_500 <= 0:
-        return 0.0
-    return (float(fair_value) - float(price_500)) / float(price_500)
+STATS_PATH_DEFAULT = Path("data/raw/stats_master_with_weights.csv")
 
 
-def classify_from_alpha(alpha: float, cfg: RecConfig) -> str:
-    if alpha >= cfg.buy_alpha:
-        return "BUY"
-    if alpha >= cfg.hold_alpha:
-        return "HOLD"
-    return "AVOID"
+def _zscore_role(s: pd.Series) -> pd.Series:
+    mu = s.mean()
+    sd = s.std(ddof=0)
+    if sd == 0:
+        return pd.Series([0.0] * len(s), index=s.index)
+    return (s - mu) / sd
 
 
-def combine_gk(alpha_price: float, grid_signal: float, cfg: RecConfig) -> float:
-    return cfg.w_price * alpha_price + cfg.w_grid * grid_signal
+def _winsorize_role(s: pd.Series) -> pd.Series:
+    low, high = s.quantile([0.01, 0.99])
+    return s.clip(low, high)
 
 
-def recommend_player(
-    player: dict,
-    *,
-    fair_value: Optional[float],
-    price_500: Optional[float],
-    role: str,
-    team: str,
-    gk_signal: Optional[float] = None,
-    cfg: Optional[RecConfig] = None,
-) -> tuple[str, float]:
-    cfg = cfg or RecConfig()
-    alpha = value_alpha_from_fair(fair_value, price_500)
+def _merge_stats(
+    players: pd.DataFrame,
+    stats_df: Optional[pd.DataFrame],
+    stats_path: Path,
+) -> pd.DataFrame:
+    if stats_df is None:
+        if not stats_path.exists():
+            raise FileNotFoundError(f"Stats file not found: {stats_path}")
+        stats_df = dataio.load_stats(str(stats_path))
 
-    if role.upper() != "P":
-        label = classify_from_alpha(alpha, cfg)
-        return label, alpha
+    stats = stats_df[["id", "name", "team", "fanta_avg"]].copy()
 
-    gk_sig = gk_signal if gk_signal is not None else 0.0
-    score = combine_gk(alpha, gk_sig, cfg)
-    label = classify_from_alpha(score, cfg)
-    return label, score
+    out = players.merge(stats[["id", "fanta_avg"]], on="id", how="left")
+    missing = out["fanta_avg"].isna()
+    if missing.any():
+        stats_alt = stats[["name", "team", "fanta_avg"]].copy()
+        stats_alt["name"] = stats_alt["name"].str.strip().str.casefold()
+        stats_alt["team"] = stats_alt["team"].str.strip().str.casefold()
+        tmp = players.loc[missing, ["name", "team"]].copy()
+        tmp["name"] = tmp["name"].str.strip().str.casefold()
+        tmp["team"] = tmp["team"].str.strip().str.casefold()
+        tmp = tmp.merge(stats_alt, on=["name", "team"], how="left")
+        out.loc[missing, "fanta_avg"] = tmp["fanta_avg"].values
+    return out
+
+
+def compute_scores(
+    players: pd.DataFrame,
+    stats_df: pd.DataFrame | None = None,
+    stats_path: Path | str = STATS_PATH_DEFAULT,
+) -> pd.DataFrame:
+    """Return dataframe with composite scores and z-scores per role."""
+
+    df = players.copy()
+    if "fanta_avg" not in df.columns:
+        df = _merge_stats(df, stats_df, Path(stats_path))
+
+    df["fanta_avg"] = pd.to_numeric(df.get("fanta_avg"), errors="coerce")
+    df["price_500"] = pd.to_numeric(df.get("price_500"), errors="coerce")
+
+    df = df.dropna(subset=["fanta_avg", "price_500"])
+
+    df["fanta_avg"] = df.groupby("role")["fanta_avg"].transform(_winsorize_role)
+
+    df["price_pct_role"] = (
+        df.groupby("role")["price_500"].rank(pct=True, ascending=True)
+    )
+    df.loc[df["price_500"] <= 0, "price_pct_role"] = 0.0
+
+    df["score_raw"] = 0.70 * df["fanta_avg"] + 0.30 * df["price_pct_role"]
+
+    df["score_z_role"] = df.groupby("role")["score_raw"].transform(_zscore_role)
+
+    return df
+
+
+def apply_recommendation(df: pd.DataFrame, cfg: RecConfig) -> pd.DataFrame:
+    """Apply BUY/HOLD/AVOID labels based on z-scores and config thresholds."""
+
+    out = df.copy()
+    out["Recommendation"] = np.select(
+        [
+            out["score_z_role"] >= cfg.buy_alpha,
+            out["score_z_role"] >= cfg.hold_alpha,
+        ],
+        ["BUY", "HOLD"],
+        default="AVOID",
+    )
+    out["BUY_alpha"] = cfg.buy_alpha
+    out["HOLD_alpha"] = cfg.hold_alpha
+    return out
+

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -3,17 +3,17 @@ import pandas as pd
 from src import ranking
 
 
-def test_rank_players_value_score():
+def test_rank_players_score():
     df = pd.DataFrame(
         {
             "id": [1, 2],
             "name": ["A", "B"],
             "team": ["T1", "T2"],
-            "role": ["P", "D"],
-            "expected_points": [20, 20],
+            "role": ["P", "P"],
+            "fanta_avg": [6.0, 5.0],
             "price_500": [10, 20],
         }
     )
-    ranked = ranking.rank_players(df, "value_score", "ALL", 2, 0)
+    ranked = ranking.rank_players(df, "score_z_role", "ALL", 2, 0)
     assert list(ranked["name"]) == ["A", "B"]
-    assert ranked.iloc[0]["value_score"] == 2
+    assert "score_z_role" in ranked.columns

--- a/tests/test_reco.py
+++ b/tests/test_reco.py
@@ -1,63 +1,42 @@
 import pandas as pd
 
-from src.reco import recommend_player
-from src.gk_grid import GKGrid, grid_signal_from_value
+from src.reco import compute_scores, apply_recommendation, RecConfig
 
 
-def make_grid(tmp_path):
-    df = pd.DataFrame([[0, 0], [2, 0]], index=["A", "B"], columns=["A", "B"])
-    path = tmp_path / "grid.csv"
-    df.to_csv(path)
-    return GKGrid(path)
+def _sample_df():
+    return pd.DataFrame(
+        [
+            {"id": 1, "name": "A", "team": "T", "role": "C", "fanta_avg": 6.0, "price_500": 10},
+            {"id": 2, "name": "B", "team": "T", "role": "C", "fanta_avg": 6.0, "price_500": 20},
+            {"id": 3, "name": "C", "team": "T", "role": "C", "fanta_avg": 7.0, "price_500": 20},
+            {"id": 4, "name": "D", "team": "T", "role": "C", "fanta_avg": 4.0, "price_500": 50},
+            {"id": 5, "name": "E", "team": "T", "role": "C", "fanta_avg": 5.0, "price_500": 5},
+        ]
+    )
 
 
-def test_player_details_fields_hidden():
-    row = {
-        "name": "Test",
-        "team": "Inter",
-        "role": "C",
-        "price_500": 15,
-        "fvm": 20,
-        "status": "AVAILABLE",
-        "sold_price": None,
-    }
-    fair_value = row.get("fvm") or row.get("estimated_price")
-    price_500 = row.get("price_500")
-    role = row["role"]
-    team = row["team"]
-    rec_label, _ = recommend_player(row, fair_value=fair_value, price_500=price_500, role=role, team=team)
-    details = {
-        "name": row["name"],
-        "team": team,
-        "role": role,
-        "price_500": price_500,
-        "status": row.get("status", "AVAILABLE"),
-        "sold_price": row.get("sold_price"),
-        "Recommendation": rec_label,
-    }
-    assert "expected_points" not in details
-    assert "value_score" not in details
+def test_monotonicity_and_labels():
+    df = compute_scores(_sample_df())
+
+    # same fanta_avg, higher price -> higher score_raw
+    a = df.loc[df["name"] == "A", "score_raw"].iloc[0]
+    b = df.loc[df["name"] == "B", "score_raw"].iloc[0]
+    assert b > a
+
+    # same price, higher fanta_avg -> higher score_raw
+    c = df.loc[df["name"] == "C", "score_raw"].iloc[0]
+    assert c > b
+
+    cfg = RecConfig(buy_alpha=0.5, hold_alpha=0.0)
+    labeled = apply_recommendation(df, cfg)
+    assert {"BUY", "HOLD", "AVOID"}.issubset(set(labeled["Recommendation"]))
 
 
-def test_reco_outfield():
-    label, score = recommend_player({}, fair_value=20, price_500=15, role="C", team="Inter")
-    assert label == "BUY"
-    assert round(score, 3) == round((20 - 15) / 15, 3)
-
-
-def test_reco_gk_unbound(tmp_path):
-    grid = make_grid(tmp_path)
-    grid_val = grid.single_score("B")
-    gk_signal = grid_signal_from_value(grid_val)
-    label, _ = recommend_player({}, fair_value=10, price_500=10, role="P", team="B", gk_signal=gk_signal)
-    assert label == "AVOID"
-
-
-def test_reco_gk_bound(tmp_path):
-    grid = make_grid(tmp_path)
-    gk_signal_unbound = grid_signal_from_value(grid.single_score("B"))
-    label_unbound, _ = recommend_player({}, fair_value=10, price_500=10, role="P", team="B", gk_signal=gk_signal_unbound)
-    gk_signal_bound = grid_signal_from_value(grid.score_pair("A", "B"))
-    label_bound, _ = recommend_player({}, fair_value=10, price_500=10, role="P", team="B", gk_signal=gk_signal_bound)
-    assert label_unbound != label_bound
-    assert label_bound == "HOLD"
+def test_thresholds_change_labels():
+    df = compute_scores(_sample_df())
+    cfg1 = RecConfig(buy_alpha=0.5, hold_alpha=0.0)
+    cfg2 = RecConfig(buy_alpha=1.5, hold_alpha=0.5)
+    labeled1 = apply_recommendation(df, cfg1)
+    labeled2 = apply_recommendation(df, cfg2)
+    assert (labeled1["score_raw"] == labeled2["score_raw"]).all()
+    assert labeled1["Recommendation"].nunique() >= labeled2["Recommendation"].nunique()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -14,8 +14,8 @@ def _sample_players() -> pd.DataFrame:
                     "name": f"{role}{i}",
                     "team": f"T{i%5}",
                     "role": role,
-                    "expected_points": 10 + i,
-                    "price_500": 10,
+                    "fanta_avg": 6 + i,
+                    "price_500": 10 + i,
                     "apps": 10,
                 }
             )
@@ -31,5 +31,5 @@ def test_optimizer_respects_quotas_and_budget():
         assert counts.get(role, 0) == qty
     assert roster["effective_price"].sum() <= 500
     first = roster.iloc[0]
-    assert first["value_score"] == first["expected_points"] / first["effective_price"]
+    assert "score_z_role" in first
 


### PR DESCRIPTION
## Summary
- compute player scores from fanta_avg and price percentiles and derive BUY/HOLD/AVOID labels using role-based z-scores
- update ranking, roster optimizer and Streamlit UI to use the new metric and drop legacy `value_score`
- document composite metric formula and add tests for monotonicity and threshold behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc472b9ff8832baf2bbfc423137643