### PR TITLE
Enhance roster optimizer with locked-player support

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,35 +1,52 @@
-import numpy as np
+import logging
 import pandas as pd
 
 from src import services
 
+ROLES_NEED = {"P": 3, "D": 8, "C": 8, "A": 6}
+
 
 def _sample_players() -> pd.DataFrame:
     rows = []
-    for role, quota in services.QUOTAS.items():
+    for role, quota in ROLES_NEED.items():
         for i in range(quota + 2):  # extra candidates
             rows.append(
                 {
                     "id": f"{role}{i}",
-                    "name": f"{role}{i}",
                     "team": f"T{i%5}",
                     "role": role,
-                    "fanta_avg": 6 + i,
                     "price_500": 10 + i,
-                    "apps": 10,
+                    "score_z_role": 1 + i / 10.0,
+                    "status": "AVAILABLE",
                 }
             )
     return pd.DataFrame(rows)
 
 
-def test_optimizer_respects_quotas_and_budget():
+def test_optimizer_handles_locked_players():
     players = _sample_players()
-    roster = services.optimize_roster(players, budget_total=500, team_cap=10)
-    assert len(roster) == sum(services.QUOTAS.values())
-    counts = roster["role"].value_counts().to_dict()
-    for role, qty in services.QUOTAS.items():
-        assert counts.get(role, 0) == qty
-    assert roster["effective_price"].sum() <= 500
-    first = roster.iloc[0]
-    assert "score_z_role" in first
+    # mark one player per role as already acquired
+    for role in ROLES_NEED.keys():
+        idx = players[players["role"] == role].index[0]
+        players.loc[idx, "my_acquired"] = 1
+        players.loc[idx, "my_price"] = 5 + idx
+
+    logger = logging.getLogger("test")
+    roster = services.optimize_roster(players, logger, budget_total=500, team_cap=10)
+
+    assert len(roster) == sum(ROLES_NEED.values())
+    locked = roster[roster["locked"] == True]
+    assert len(locked) == len(ROLES_NEED)
+
+    expected_locked = players.loc[players["my_acquired"] == 1, "my_price"].sum()
+    assert roster["budget_locked"].iloc[0] == expected_locked
+
+
+def test_optimizer_best_effort_on_low_budget():
+    players = _sample_players()
+    logger = logging.getLogger("test")
+    roster = services.optimize_roster(players, logger, budget_total=50, team_cap=10)
+
+    assert len(roster) < sum(ROLES_NEED.values())
+    assert roster["budget_left"].iloc[0] >= 0
 


### PR DESCRIPTION
## Summary
- Rewrite `optimize_roster` to include locked players, budget tracking and upgrade loop
- Add tests covering locked-player inclusion and best-effort behavior under tight budgets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4bc8fc48832b8f77c33dc951f7ac