### PR TITLE
feat: add logger shim for roster optimization

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -369,7 +369,7 @@ st.subheader("Roster Optimizer")
 budget_total = st.number_input("Total budget", value=500)
 team_cap = st.number_input("Team cap", value=3)
 if st.button("Optimize"):
-    roster = services.optimize_roster(players, log, budget_total, team_cap)
+    roster = services.optimize_roster(players, st, budget_total, team_cap)
     roster.to_csv(f"{OUTPUT_DIR}/recommended_roster.csv", index=False)
     st.dataframe(
         roster[


### PR DESCRIPTION
## Summary
- add `_mk_logger` shim to normalize log objects, with fallback to Streamlit or stdout
- use logger shim in `optimize_roster`
- pass Streamlit object as logger from UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e151bbc832baedb4e9e6d494472