### PR TITLE
Add cumulative roster budget and UI fallback

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -371,19 +371,10 @@ team_cap = st.number_input("Team cap", value=3)
 if st.button("Optimize"):
     roster = services.optimize_roster(players, st, budget_total, team_cap)
     roster.to_csv(f"{OUTPUT_DIR}/recommended_roster.csv", index=False)
-    st.dataframe(
-        roster[
-            [
-                "role",
-                "name",
-                "team",
-                "price_500",
-                "score_raw",
-                "score_z_role",
-                "cum_budget",
-            ]
-        ]
-    )
+    cols = ["role", "name", "team", "price_500", "score_raw", "score_z_role"]
+    if "cum_budget" in roster.columns:
+        cols.append("cum_budget")
+    st.dataframe(roster[cols])
 
 st.subheader("Il mio roster")
 

--- a/src/services.py
+++ b/src/services.py
@@ -199,6 +199,17 @@ def optimize_roster(
     roster, pool, budget_left = upgrade_loop(roster, pool, budget_left, team_cap)
 
     roster = roster.sort_values(["role", "score_z_role", "price_500"], ascending=[True, False, False]).reset_index(drop=True)
+
+    # normalizza colonne prezzo effettivo
+    if "eff_price" not in roster.columns:
+        roster["eff_price"] = roster["price_500"]
+    roster["eff_price"] = pd.to_numeric(roster["eff_price"], errors="coerce").fillna(0.0)
+
+    # cumulato di spesa riga-per-riga per la UI
+    roster["spent"] = roster["eff_price"].astype(float)
+    roster["cum_budget"] = roster["spent"].cumsum()
+
+    # metadati di budget (ripetuti su ogni riga per semplicità di export)
     roster["budget_total"] = float(budget_total)
     roster["budget_locked"] = float(budget_locked)
     roster["budget_left"] = float(budget_left)


### PR DESCRIPTION
## Summary
- compute per-player spending and cumulative budget in optimize_roster
- avoid UI crash by displaying `cum_budget` only if present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc4f922608832b823150c5be18f12b