### PR TITLE
Handle logger.info messages for Streamlit compatibility

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -272,9 +272,7 @@ def optimize_roster(
         locked["locked"] = False
         locked["eff_price"] = []
     logger.info(
-        "Locked seen -> total=%d | by role=%s",
-        len(locked),
-        locked["role"].value_counts().to_dict() if not locked.empty else {},
+        f"Locked seen -> total={len(locked)} | by role={locked['role'].value_counts().to_dict() if not locked.empty else {}}"
     )
 
     budget_locked = locked["eff_price"].sum() if not locked.empty else 0.0


### PR DESCRIPTION
## Summary
- use f-strings for `optimize_roster` logger message to avoid extra args with Streamlit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5c2c45ec832b900b5ebd62979f8b