### PR TITLE
Show goalkeeper z-score in player details

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -310,10 +310,11 @@ if p is not None:
         "status": "SOLD" if p.is_sold else "AVAILABLE",
         "sold_price": int(p.sold_price) if p.sold_price is not None else None,
     }
+    details["score_z_role"] = round(float(score_z), 3) if score_z is not None else None
+
     # Aggiungi Recommendation solo se non è un portiere
     if role != "P" and rec_label is not None:
         details["Recommendation"] = f"{rec_label}"
-        details["score_z_role"] = round(float(score_z), 3) if score_z is not None else None
 
     if role == "P":
         grid = GKGrid()  # default: data/raw/goalkeepers_grid_matrix_square.csv


### PR DESCRIPTION
## Summary
- always include `score_z_role` in player details so goalkeepers display their z-score

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5dc01bf0832b844a5dfa73129c83