### PR TITLE
Avoid duplicate entries in rankings

### DIFF
--- a/src/ranking.py
+++ b/src/ranking.py
@@ -33,6 +33,14 @@ def rank_players(
     if role != "ALL" and "role" in data.columns:
         data = data[data["role"] == role]
 
+    # Deduplicate potential multiple entries for the same player so that the
+    # ranking list doesn't contain duplicates. Prefer the last occurrence to be
+    # consistent with ``services.optimize_roster`` behaviour.
+    if "id" in data.columns:
+        data = data.drop_duplicates(subset=["id"], keep="last")
+    elif {"name", "team"}.issubset(data.columns):
+        data = data.drop_duplicates(subset=["name", "team"], keep="last")
+
     price = pd.to_numeric(data.get("price_500"), errors="coerce").fillna(0)
     data["effective_price"] = price.clip(lower=1)
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -17,3 +17,19 @@ def test_rank_players_score():
     ranked = ranking.rank_players(df, "score_z_role", "ALL", 2, 0)
     assert list(ranked["name"]) == ["A", "B"]
     assert "score_z_role" in ranked.columns
+
+
+def test_rank_players_deduplicates():
+    df = pd.DataFrame(
+        {
+            "id": [1, 1, 2],
+            "name": ["A", "A", "B"],
+            "team": ["T1", "T1", "T2"],
+            "role": ["P", "P", "P"],
+            "fanta_avg": [6.0, 6.0, 5.0],
+            "price_500": [10, 10, 20],
+        }
+    )
+    ranked = ranking.rank_players(df, "score_z_role", "ALL", 10, 0)
+    assert ranked["id"].tolist().count(1) == 1
+    assert len(ranked) == 2


### PR DESCRIPTION
## Summary
- Deduplicate players in `rank_players` to prevent repeated entries in top lists
- Test ranking with duplicate input data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb2caa570832b8a965acd6d5d98a7