### PR TITLE
Deduplicate player names in Top 10 table

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -282,7 +282,11 @@ role_filter = st.selectbox("Ruolo", ["P", "D", "C", "A"])
 
 available_ids = [p.id for p in _list_players(role=role_filter, include_sold=False)]
 top10 = players[(players["role"].eq(role_filter)) & (players["id"].isin(available_ids))]
-top10 = top10.sort_values("price_500", ascending=False).head(10)
+top10 = (
+    top10.sort_values("price_500", ascending=False)
+    .drop_duplicates(subset="name")
+    .head(10)
+)
 st.caption("Top 10 disponibili per price_500")
 st.dataframe(top10[["name", "team", "price_500"]])
 


### PR DESCRIPTION
## Summary
- ensure Top 10 table shows unique player names by dropping duplicates after sorting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcb4237bec832bbe0ff89c498a011f